### PR TITLE
Customizable API url and redirect_uri fix

### DIFF
--- a/lib/omniauth/strategies/recharge.rb
+++ b/lib/omniauth/strategies/recharge.rb
@@ -30,6 +30,12 @@ module OmniAuth
         api_url = ENV['RECHARGE_API_URL'] || 'https://api.rechargeapps.com/'
         @raw_info ||= access_token.get(api_url).parsed
       end
+
+       def callback_url
+        # make sure the query string doesnt get added to the redirect_uri
+        # https://github.com/intridea/omniauth-oauth2/issues/93
+        full_host + script_name + callback_path
+      end
     end
   end
 end

--- a/lib/omniauth/strategies/recharge.rb
+++ b/lib/omniauth/strategies/recharge.rb
@@ -4,11 +4,12 @@ module OmniAuth
   module Strategies
     class Recharge < OmniAuth::Strategies::OAuth2
 
+      option :provider_ignores_state, false
+
       option :client_options, {
           :site          => 'https://shopifysubscriptions.com',
           :authorize_url => '/oauth/authorize',
-          :token_url     => '/oauth/token',
-          :provider_ignores_state => true
+          :token_url     => '/oauth/token'
       }
 
       uid{ raw_info['store']['store_id'] }
@@ -26,7 +27,8 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('https://api.rechargeapps.com/').parsed
+        api_url = ENV['RECHARGE_API_URL'] || 'https://api.rechargeapps.com/'
+        @raw_info ||= access_token.get(api_url).parsed
       end
     end
   end


### PR DESCRIPTION
For testing purposes its handy to be able to override the base API url. This will allow the user to specify 
the environment variable `RECHARGE_API_URL`, and will default to `https://api.rechargeapps.com` when its not specified.

Additionally I discovered that there is an issue in omniauth where it adds query parameters to the redirect_uri when it does a POST to get the access token. This results in a redirect_uri mismatch error. As suggested in the omniauth issue I overrode the callback_url function so it does not append a query string or fragment.